### PR TITLE
Change struct of options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hankei6km/remark-numbers",
-  "version": "0.2.0-pre.6",
+  "version": "0.2.0-pre.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hankei6km/remark-numbers",
-  "version": "0.2.0-pre.6",
+  "version": "0.2.0-pre.7",
   "description": "remark plugin to assign serial numbers",
   "author": "hankei6km <hankei6km@gmail.com> (https://github.com/hankei6km)",
   "license": "MIT",

--- a/src/lib/numbers.ts
+++ b/src/lib/numbers.ts
@@ -13,7 +13,10 @@ import { decodeParents, getRefernceFromLabel, normalizeOpts } from './util.js'
 
 export const directiveName = 'num'
 
-export type RemarkNumbersOptions = { template?: string[] }
+export type RemarkNumbersOptions = {
+  template?: string[]
+  keepDefaultTemplate?: boolean
+}
 export const remarkNumbersOptionsDefault: Required<RemarkNumbersOptions> = {
   template: [
     `
@@ -35,7 +38,8 @@ export const remarkNumbersOptionsDefault: Required<RemarkNumbersOptions> = {
 :num[:num[sec]-:num]{series=tbl}
 :::
 `
-  ]
+  ],
+  keepDefaultTemplate: false
 }
 
 export function errMessageNotDefined(id: string): Text {
@@ -56,7 +60,11 @@ export const remarkNumbers: Plugin<
 
   // template をパース.
   // extension は directive のみ(gfm などは必要ないと思う).
-  const templates: string[] = nopts.template
+  const templates: string[] = (
+    nopts.keepDefaultTemplate
+      ? remarkNumbersOptionsDefault.template.concat(nopts.template)
+      : nopts.template
+  )
     .filter((template) => template)
     .map((template) =>
       JSON.stringify(

--- a/src/lib/numbers.ts
+++ b/src/lib/numbers.ts
@@ -13,9 +13,10 @@ import { decodeParents, getRefernceFromLabel, normalizeOpts } from './util.js'
 
 export const directiveName = 'num'
 
-export type RemarkNumbersOptions = { template?: string }
+export type RemarkNumbersOptions = { template?: string[] }
 export const remarkNumbersOptionsDefault: Required<RemarkNumbersOptions> = {
-  template: `
+  template: [
+    `
 :::num{reset counter}
 # :num{#sec}
 ## :num{#subsec}
@@ -33,7 +34,8 @@ export const remarkNumbersOptionsDefault: Required<RemarkNumbersOptions> = {
 :num[:num[sec]-:num]{series=chart}
 :num[:num[sec]-:num]{series=tbl}
 :::
-` // とりあえず.
+`
+  ]
 }
 
 export function errMessageNotDefined(id: string): Text {
@@ -54,9 +56,9 @@ export const remarkNumbers: Plugin<
 
   // template をパース.
   // extension は directive のみ(gfm などは必要ないと思う).
-  const templates: string[] = nopts
-    .filter(({ template }) => template)
-    .map(({ template }) =>
+  const templates: string[] = nopts[0].template
+    .filter((template) => template)
+    .map((template) =>
       JSON.stringify(
         // 今回はこれで対応できると思う.
         fromMarkdown(template, {

--- a/src/lib/numbers.ts
+++ b/src/lib/numbers.ts
@@ -52,11 +52,11 @@ export const remarkNumbers: Plugin<
 > = function remarkNumbers(
   opts?: RemarkNumbersOptions | RemarkNumbersOptions[]
 ): Transformer {
-  const nopts = normalizeOpts(opts)
+  const nopts = normalizeOpts(opts)[0]
 
   // template をパース.
   // extension は directive のみ(gfm などは必要ないと思う).
-  const templates: string[] = nopts[0].template
+  const templates: string[] = nopts.template
     .filter((template) => template)
     .map((template) =>
       JSON.stringify(

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -10,7 +10,11 @@ function _normalizeOpts(
     template:
       opts.template !== undefined
         ? opts.template
-        : remarkNumbersOptionsDefault.template
+        : remarkNumbersOptionsDefault.template,
+    keepDefaultTemplate:
+      opts.keepDefaultTemplate !== undefined
+        ? opts.keepDefaultTemplate
+        : remarkNumbersOptionsDefault.keepDefaultTemplate
   }
 }
 

--- a/test/lib/numbers.spec.ts
+++ b/test/lib/numbers.spec.ts
@@ -1047,4 +1047,58 @@ describe('remarkNumbers() opts.template', () => {
 121
 `)
   })
+  it('should use passed template with default template', async () => {
+    expect(
+      await f(
+        `# test
+
+## test :num[sec]
+
+:num[cnt1]
+
+### test :num[sec]-:num[subsec]
+
+:num{#foo}:num{#bar}
+
+### test :num[sec]-:num[subsec]
+
+:num{#car}
+
+:num[foo]:num[bar]:num[car]
+`,
+        {
+          template: [
+            `
+:::num{reset counter}
+# :num{#cnt1}
+:::
+:::num{increment counter}
+## :num{#cnt1}
+:::
+:::num{reset assign}
+## :num
+### :num
+:::
+`
+          ],
+          keepDefaultTemplate: true
+        }
+      )
+    ).toEqual(`# test
+
+## test 1
+
+1
+
+### test 1-1
+
+12
+
+### test 1-2
+
+1
+
+121
+`)
+  })
 })

--- a/test/lib/numbers.spec.ts
+++ b/test/lib/numbers.spec.ts
@@ -959,7 +959,8 @@ describe('remarkNumbers() opts.template', () => {
 :num[foo]:num[bar]:num[car]
 `,
         {
-          template: `
+          template: [
+            `
 :::num{reset counter}
 # :num{#cnt1}
 :::
@@ -971,6 +972,7 @@ describe('remarkNumbers() opts.template', () => {
 ### :num
 :::
 `
+          ]
         }
       )
     ).toEqual(`# test
@@ -1009,16 +1011,14 @@ describe('remarkNumbers() opts.template', () => {
 
 :num[foo]:num[bar]:num[car]
 `,
-        [
-          {
-            template: `
+
+        {
+          template: [
+            `
 :::num{reset counter}
 # :num{#cnt1}
-:::
-`
-          },
-          {
-            template: `
+:::`,
+            `
 :::num{increment counter}
 ## :num{#cnt1}
 :::
@@ -1027,8 +1027,8 @@ describe('remarkNumbers() opts.template', () => {
 ### :num
 :::
 `
-          }
-        ]
+          ]
+        }
       )
     ).toEqual(`# test
 

--- a/test/lib/util.spec.ts
+++ b/test/lib/util.spec.ts
@@ -6,26 +6,21 @@ describe('normalizeOpts()', () => {
   it('should set default', () => {
     expect(normalizeOpts()).toEqual([remarkNumbersOptionsDefault])
     expect(normalizeOpts({})).toEqual([remarkNumbersOptionsDefault])
+    expect(normalizeOpts([{}])).toEqual([remarkNumbersOptionsDefault])
   })
   it('should use passed fields', () => {
-    expect(normalizeOpts({ template: [''] })).toEqual([{ template: [''] }])
+    expect(normalizeOpts({ template: [''] })).toEqual([
+      { template: [''], keepDefaultTemplate: false }
+    ])
     expect(normalizeOpts({ template: ['test'] })).toEqual([
       {
-        template: ['test']
+        template: ['test'],
+        keepDefaultTemplate: false
       }
     ])
-  })
-  it('should use passed fields(array)', () => {
     expect(
-      normalizeOpts([{ template: ['test1'] }, { template: ['test2'] }])
-    ).toEqual([
-      {
-        template: ['test1']
-      },
-      {
-        template: ['test2']
-      }
-    ])
+      normalizeOpts({ template: ['test'], keepDefaultTemplate: true })
+    ).toEqual([{ template: ['test'], keepDefaultTemplate: true }])
   })
 })
 

--- a/test/lib/util.spec.ts
+++ b/test/lib/util.spec.ts
@@ -8,22 +8,22 @@ describe('normalizeOpts()', () => {
     expect(normalizeOpts({})).toEqual([remarkNumbersOptionsDefault])
   })
   it('should use passed fields', () => {
-    expect(normalizeOpts({ template: '' })).toEqual([{ template: '' }])
-    expect(normalizeOpts({ template: 'test' })).toEqual([
+    expect(normalizeOpts({ template: [''] })).toEqual([{ template: [''] }])
+    expect(normalizeOpts({ template: ['test'] })).toEqual([
       {
-        template: 'test'
+        template: ['test']
       }
     ])
   })
   it('should use passed fields(array)', () => {
     expect(
-      normalizeOpts([{ template: 'test1' }, { template: 'test2' }])
+      normalizeOpts([{ template: ['test1'] }, { template: ['test2'] }])
     ).toEqual([
       {
-        template: 'test1'
+        template: ['test1']
       },
       {
-        template: 'test2'
+        template: ['test2']
       }
     ])
   })


### PR DESCRIPTION
- Change type of "opts.template" from "string" to "string[]"
- Use only "opts[0]" to apply options to the plugin
- Add "keepDefaultTemplate" filed to "RemarkNumbersOptions"
